### PR TITLE
feat: integrate MyPlot view and update routing architecture

### DIFF
--- a/apps/frontend/src/pages/MyPlot/components/LeaseInfo.tsx
+++ b/apps/frontend/src/pages/MyPlot/components/LeaseInfo.tsx
@@ -1,0 +1,19 @@
+type leaseInfoProps = {
+  leaseStartDate: string;
+  leaseEndDate: string;
+};
+
+export function LeaseInfo({ leaseStartDate, leaseEndDate }: leaseInfoProps) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-10 text-left">
+      <div className="space-y-1">
+        <p className="text-gray-400 text-xs font-bold uppercase">Lease Started</p>
+        <p className="text-lg text-gray-800 font-medium">{leaseStartDate}</p>
+      </div>
+      <div className="space-y-1">
+        <p className="text-gray-400 text-xs font-bold uppercase">Lease Expires</p>
+        <p className="text-lg text-gray-800 font-medium">{leaseEndDate}</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/MyPlot/components/LeaseStatusBadge.tsx
+++ b/apps/frontend/src/pages/MyPlot/components/LeaseStatusBadge.tsx
@@ -1,0 +1,17 @@
+type StatusBadgeProps = {
+  status: "Active" | "Warning" | "Overdue";
+};
+
+export default function LeaseStatusBadge({ status }: StatusBadgeProps) {
+  const statusColor = {
+    Active: "bg-green-100 text-green-800 border-green-200",
+    Overdue: "bg-red-100 text-red-800 border-red-200",
+    Warning: "bg-yellow-100 text-yellow-800 border-yellow-200",
+  }[status];
+
+  return (
+    <div className={`px-4 py-1.5 rounded-full border text-sm font-bold uppercase tracking-wider ${statusColor}`}>
+      {status}
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/MyPlot/components/PlotCard.tsx
+++ b/apps/frontend/src/pages/MyPlot/components/PlotCard.tsx
@@ -1,0 +1,22 @@
+import type { PlotData } from "../../../services/plotServices";
+import { LeaseInfo } from "./LeaseInfo";
+import { PlotCardHeader } from "./PlotCardHeader";
+import { ResponsibilityList } from "./ResponsibilityList";
+
+type PlotCardProps = {
+  plot: PlotData;
+};
+
+export default function PlotCard({ plot }: PlotCardProps) {
+  return (
+    <div className="bg-white rounded-2xl shadow-sm border border-gray-200 overflow-hidden">
+      <PlotCardHeader plotId={plot.plotId} size={plot.size} />
+
+      <div className="p-8">
+        <LeaseInfo leaseEndDate={plot.leaseEndDate} leaseStartDate={plot.leaseStartDate} />
+
+        <ResponsibilityList responsibilities={plot.responsibilities} />
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/MyPlot/components/PlotCardHeader.tsx
+++ b/apps/frontend/src/pages/MyPlot/components/PlotCardHeader.tsx
@@ -1,0 +1,21 @@
+type PlotCardHeaderProps = {
+  plotId: string;
+  size: string;
+};
+
+export function PlotCardHeader({ plotId, size }: PlotCardHeaderProps) {
+  return (
+    <div className="bg-green-700 px-8 py-6 text-white text-left">
+      <div className="flex items-center justify-between">
+        <div>
+          <span className="text-green-200 text-xs font-bold uppercase tracking-widest">Plot Identifier</span>
+          <h2 className="text-3xl font-bold">{plotId}</h2>
+        </div>
+        <div className="text-right">
+          <span className="text-green-200 text-xs font-bold uppercase tracking-widest">Dimensions</span>
+          <p className="text-xl font-semibold">{size}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/MyPlot/components/PlotFooterNote.tsx
+++ b/apps/frontend/src/pages/MyPlot/components/PlotFooterNote.tsx
@@ -1,0 +1,3 @@
+export default function PlotFooterNote() {
+  return <p className="text-center text-sm text-gray-400">Issues with your plot? Contact the Garden Coordinator.</p>;
+}

--- a/apps/frontend/src/pages/MyPlot/components/PlotHeader.tsx
+++ b/apps/frontend/src/pages/MyPlot/components/PlotHeader.tsx
@@ -1,0 +1,20 @@
+import LeaseStatusBadge from "./LeaseStatusBadge";
+
+type PlotHeaderProps = {
+  leaseStatus: "Active" | "Warning" | "Overdue";
+};
+
+export default function PlotHeader({ leaseStatus }: PlotHeaderProps) {
+  return (
+    <div className="flex flex-col md:flex-row md:items-end justify-between gap-4">
+      <div className="text-left">
+        <h1 className="text-4xl font-extrabold text-gray-900 tracking-tight">My Plot</h1>
+        <p className="text-gray-500 mt-1">Manage your garden space and communal duties</p>
+      </div>
+      <div className="flex flex-col items-start md:items-end ">
+        <p className="text-xs text-gray-400 uppercase font-bold tracking-widest mb-1">Lease Status</p>
+        <LeaseStatusBadge status={leaseStatus} />
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/MyPlot/components/ResponsibilityItem.tsx
+++ b/apps/frontend/src/pages/MyPlot/components/ResponsibilityItem.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+import CheckCircleIcon from "./icons/CheckCircleIcon";
+
+type ResponsibilityItemProps = {
+  id: string;
+  responsibility: string;
+  initialCompleted: boolean;
+};
+
+export default function ResponsibilityItem({ id, responsibility, initialCompleted }: ResponsibilityItemProps) {
+  const [isCompleted, setIsCompleted] = useState(initialCompleted);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleToggle = async () => {
+    if (isLoading) return;
+
+    // Optimistic UI update
+    const previousState = isCompleted;
+    setIsCompleted(!isCompleted);
+    setIsLoading(true);
+
+    try {
+      // FUTURE API CALL: Uncomment when backend is ready
+
+      // await fetch(`/api/responsibilities/${id}`, {
+      //   method: "PATCH",
+      //   body: JSON.stringify({ status: !previousState ? "completed" : "pending" }),
+      // });
+
+      // MOCK API CALL: Simulate a 500ms delay to test the loading state
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      console.log(`Mock PATCH request sent for ID ${id} to state ${!previousState}`);
+    } catch (error) {
+      console.error("Failed to update status", error);
+      setIsCompleted(previousState);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <button
+      className={`flex w-full items-start gap-4 p-4 rounded-xl border cursor-pointer
+            ${isCompleted ? `bg-transparent border-transparent` : "bg-gray-50 border-gray-100"}`}
+      onClick={handleToggle}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          handleToggle();
+        }
+      }}
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className={`mt-1 w-5 h-5 shrink-0 flex items-center justify-center border-2 
+                ${isCompleted ? `bg-green-500 border-green-500 rounded-full` : `border-green-500 rounded-full`}`}
+      >
+        {isCompleted && <CheckCircleIcon />}
+      </div>
+      <p className={`leading-tight ${isCompleted ? `text-gray-400 line-through` : `text-gray-700`}`}>
+        {responsibility}
+      </p>
+    </button>
+  );
+}

--- a/apps/frontend/src/pages/MyPlot/components/ResponsibilityList.tsx
+++ b/apps/frontend/src/pages/MyPlot/components/ResponsibilityList.tsx
@@ -1,0 +1,24 @@
+import type { Responsibility } from "../../../services/plotServices";
+import ResponsibilityItem from "./ResponsibilityItem";
+
+type ResponsibilityListProps = {
+  responsibilities: Responsibility[];
+};
+
+export function ResponsibilityList({ responsibilities }: ResponsibilityListProps) {
+  return (
+    <div className="border-t border-gray-100 pt-8 text-left">
+      <h3 className="text-xl font-bold text-gray-900 mb-6">Communal Responsibilities</h3>
+      <div className="space-y-3">
+        {responsibilities.map((resp) => (
+          <ResponsibilityItem
+            id={resp.id}
+            initialCompleted={resp.initialCompleted}
+            key={resp.id}
+            responsibility={resp.description}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/MyPlot/components/icons/CheckCircleIcon.tsx
+++ b/apps/frontend/src/pages/MyPlot/components/icons/CheckCircleIcon.tsx
@@ -1,0 +1,12 @@
+type IconProps = {
+  className?: string;
+};
+
+export default function CheckCircleIcon({ className }: IconProps) {
+  return (
+    <svg className={className} fill="currentColor" viewBox="0 -960 960 960" xmlns="http://www.w3.org/2000/svg">
+      <title>Check</title>
+      <path d="m424-296 282-282-56-56-226 226-114-114-56 56 170 170Zm56 216q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z" />
+    </svg>
+  );
+}

--- a/apps/frontend/src/pages/MyPlot/index.tsx
+++ b/apps/frontend/src/pages/MyPlot/index.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+import type { PlotData } from "../../services/plotServices";
+import { fetchMyPlotData } from "../../services/plotServices";
+import PlotCard from "./components/PlotCard";
+import PlotFooterNote from "./components/PlotFooterNote";
+import PlotHeader from "./components/PlotHeader";
+
+export default function MyPlotPage() {
+  const [plotData, setPlotData] = useState<PlotData | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    const loadPlotData = async () => {
+      try {
+        const plotData = await fetchMyPlotData();
+        setPlotData(plotData);
+      } catch (error) {
+        console.error("Failed to fetch plot data:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    loadPlotData();
+  }, []);
+
+  //  Handle the loading state
+  if (isLoading) {
+    return (
+      <div className="min-h-screen w-full bg-gray-50 flex items-center justify-center">
+        <p className="text-gray-500 font-medium animate-pulse">Loading Your Garden Data... 🪴</p>
+      </div>
+    );
+  }
+
+  // handle case where the data failed to load
+  if (!plotData) {
+    return (
+      <div className="min-h-screen w-full bg-gray-50 flex items-center justify-center">
+        <p className="text-red-500 font-medium ">Failed to Load Plot Data </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen w-full bg-gray-50 p-4 md:p-8">
+      <div className="w-full max-w-7xl mx-auto space-y-6">
+        {/* Header Section */}
+        <PlotHeader leaseStatus={plotData.leaseStatus} />
+        {/* Main Card */}
+        <PlotCard plot={plotData} />
+
+        <PlotFooterNote />
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/routes.tsx
+++ b/apps/frontend/src/routes.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter, Navigate } from "react-router";
 import { ProtectedRoute } from "@/components/protected-route.tsx";
 import { Dashboard } from "./pages/Dashboard.tsx";
 import { Login } from "./pages/login.tsx";
+import MyPlot from "./pages/MyPlot";
 
 export const router = createBrowserRouter([
   {
@@ -19,5 +20,13 @@ export const router = createBrowserRouter([
       </ProtectedRoute>
     ),
     path: "dashboard",
+  },
+  {
+    element: (
+      <ProtectedRoute>
+        <MyPlot />
+      </ProtectedRoute>
+    ),
+    path: "my-plot",
   },
 ]);

--- a/apps/frontend/src/services/plotServices.ts
+++ b/apps/frontend/src/services/plotServices.ts
@@ -1,0 +1,49 @@
+export type Responsibility = {
+  id: string;
+  description: string;
+  initialCompleted: boolean;
+};
+
+export type PlotData = {
+  userId: string;
+  plotId: string;
+  size: string;
+  leaseStartDate: string;
+  leaseEndDate: string;
+  leaseStatus: "Active" | "Warning" | "Overdue";
+  responsibilities: Responsibility[];
+};
+
+//  simulate an async API call with a Promise
+export const fetchMyPlotData = async (): Promise<PlotData> => {
+  // simulating network delay
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({
+        leaseEndDate: "2026-10-31",
+        leaseStartDate: "2025-03-01",
+        leaseStatus: "Active",
+        plotId: "B-14",
+        responsibilities: [
+          {
+            description: "Mow shared path (Section B) by Sunday",
+            id: "101",
+            initialCompleted: false,
+          },
+          {
+            description: "Clean communal tool shed on Wednesday",
+            id: "102",
+            initialCompleted: true, // Let's make one completed for testing
+          },
+          {
+            description: "Ensure water spigot B is turned off daily",
+            id: "103",
+            initialCompleted: false,
+          },
+        ],
+        size: "10x10 In-Ground",
+        userId: "t12457",
+      });
+    }, 500); // 500 ms delay
+  });
+};


### PR DESCRIPTION
### Summary

This PR introduces the **MyPlot** page for users, including routing setup and a temporary service layer to simulate async data fetching.

---

### Changes Made

#### 1. MyPlot Page
- Created the `MyPlot` page component.
- Displays:
  - Plot metadata (ID, size, lease dates, lease status)
  - User responsibilities.
- Uses typed state (`PlotData | null`) to safely handle async loading.

#### 2. Routing
- Added route configuration in `routes.tsx` for the MyPlot page.
- Integrated the page into the existing router structure.

#### 3. plotServices (Mock Service Layer)
- Created `plotServices` to simulate an async API call.
- Implemented `fetchMyPlotData()` returning a `Promise<PlotData>`.
- Added a 500ms artificial delay to mimic network latency.